### PR TITLE
Added support for channel ROI

### DIFF
--- a/src/pysimmmulator/simmmulate.py
+++ b/src/pysimmmulator/simmmulate.py
@@ -259,6 +259,13 @@ class simulate:
         
         logger.info("You have completed running step 7: Expanding to maximum data frame.")
     
+    def calculate_channel_roi(self):
+        self.channel_roi = {}
+        for channel in self.basic_params.all_channels:
+            total_cpa = self.mmm_df[f"{channel}_spend"].sum() / self.mmm_df[f"{channel}_conversions"].sum()
+            total_roi = (self.basic_params.revenue_per_conv - total_cpa) / total_cpa
+            self.channel_roi[channel] = total_roi
+    
     def finalize_output(self, aggregation_level: str) -> None:
         output_params = output_parameters(aggregation_level)
         metric_cols = []

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -52,6 +52,17 @@ def tests_step7_consolidatedataframe():
     sim.calculate_conversions()
     sim.consolidate_dataframe()
 
+def tests_step8_roi():
+    sim = simmmulate.simulate(load_parameters.my_basic_params)
+    sim.simulate_baseline(**load_parameters.cfg["baseline_params"])
+    sim.simulate_ad_spend(**load_parameters.cfg["ad_spend_params"])
+    sim.simulate_media(**load_parameters.cfg["media_params"])
+    sim.simulate_cvr(**load_parameters.cfg["cvr_params"])
+    sim.simulate_decay_returns(**load_parameters.cfg["adstock_params"])
+    sim.calculate_conversions()
+    sim.consolidate_dataframe()
+    sim.calculate_channel_roi()
+
 def tests_step9_consolidatedataframe():
     sim = simmmulate.simulate(load_parameters.my_basic_params)
     sim.simulate_baseline(**load_parameters.cfg["baseline_params"])


### PR DESCRIPTION
# Description
Addition of simulation support calculating the simulated channel roi. Useful for comparing to MMM output for validation.

## Type of change
New feature (non-breaking change which adds functionality)