### PR TITLE
Update CLI input arg key

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,20 @@ sim.consolidate_dataframe()
 sim.calculate_channel_roi()
 sim.finalize_output()
 ```
+### Run via CLI
+
+A configuration file is required as input for this and should be passed as seen below. An output path can also be passed via `-o`, however when not passed the current working directory will be used.
+
+```bash
+pysimmm -i example_config.yaml -o .
+```
+
+## Development
+
+Setting up a dev environment
+
+```bash
+conda create --prefix=./env python=3.11
+conda activate ./env
+pip install -e '.[dev]'
+```

--- a/src/pysimmmulator/command_line.py
+++ b/src/pysimmmulator/command_line.py
@@ -1,9 +1,10 @@
 from pysimmmulator import load_config, simmmulate
 import pandas as pd
 import argparse
+import os
 
 
-def run_with_config(config_path):
+def run_with_config(config_path, output_path):
     """Initiates `simmmulator` and executes `simmmmulator.run_with_config` against the passed config filepath
 
     Args:
@@ -14,8 +15,8 @@ def run_with_config(config_path):
     (mmm_input_df, channel_roi) = sim.run_with_config(config=cfg)
 
     # save to current directory. Should be an optional argument for this
-    mmm_input_df.to_csv("mmm_input_df.csv", index=False)
-    pd.DataFrame.from_dict(channel_roi, orient="index", columns=["true_roi"]).to_csv("channel_roi.csv")
+    mmm_input_df.to_csv(os.path.join(output_path,"mmm_input_df.csv"), index=False)
+    pd.DataFrame.from_dict(channel_roi, orient="index", columns=["true_roi"]).to_csv(os.path.join(output_path,"channel_roi.csv"))
 
 
 def main():
@@ -27,4 +28,4 @@ def main():
         "-o", "--output_path", action="store", help="Provides output destination", default="."
     )
     args = arg_parser.parse_args()
-    run_with_config(config_path=args.config_path)
+    run_with_config(config_path=args.input_config, output_path=args.output_path)

--- a/src/pysimmmulator/command_line.py
+++ b/src/pysimmmulator/command_line.py
@@ -21,7 +21,7 @@ def run_with_config(config_path):
 def main():
     arg_parser = argparse.ArgumentParser()
     arg_parser.add_argument(
-        "-c", "--config_path", action="store", help="Provides configuration file path for simulation"
+        "-i", "--input-config", action="store", help="Provides configuration file path for simulation"
     )
     arg_parser.add_argument(
         "-o", "--output_path", action="store", help="Provides output destination", default="."

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,7 @@ import subprocess
 
 
 def test_cli():
-    subprocess.run(["pysimmm", "-c", "example_config.yaml", "-o", "."])
+    subprocess.run(["pysimmm", "-i", "example_config.yaml", "-o", "."])
     import os
     #cleanup
     os.remove("./mmm_input_df.csv")


### PR DESCRIPTION
* Updates the CLI from `-c`/`--config_path` to `-i`/`--input_config`. `-i` being a more standard argument
* Adds documentation to README on how to use the CLI
* Adds documentation to README on how to set up the dev environment (for those with less experience using `pyproject.yaml`) 